### PR TITLE
Feature/ryouma/fixes

### DIFF
--- a/laravel_app/app/Http/Controllers/Api/AccountController.php
+++ b/laravel_app/app/Http/Controllers/Api/AccountController.php
@@ -121,6 +121,35 @@ class AccountController extends Controller
             }
             return $post;
         });
+        $posts->transform(function ($post) {
+            // リアクションの種類ごとの情報を格納する配列
+            $reactionInfo = [];
+            
+            // 各リアクションを処理
+            foreach ($post->post_reactions as $reaction) {
+                $reactionName = $reaction->reaction->reaction_name;
+                
+                // まだ存在しないリアクションタイプの場合は初期化
+                if (!isset($reactionInfo[$reactionName])) {
+                    $reactionInfo[$reactionName] = [
+                        'count' => 0,
+                        'image' => $reaction->reaction->reaction_image,
+                        'name' => $reactionName
+                    ];
+                }
+                
+                // カウントをインクリメント
+                $reactionInfo[$reactionName]['count']++;
+                
+                // 既存の変換処理
+                $reaction->reaction_name = $reactionName;
+            }
+            
+            // 配列のインデックスをリセットして連番の配列に変換
+            $post->reaction_stats = array_values($reactionInfo);
+            
+            return $post;
+        });
 
         return response()->json([
             'success' => true,

--- a/laravel_app/app/Http/Controllers/Api/PostController.php
+++ b/laravel_app/app/Http/Controllers/Api/PostController.php
@@ -34,6 +34,22 @@ class PostController extends Controller
                     return $file;
                 });
             }
+
+            $reactionInfo = [];
+            foreach ($post->post_reactions as $reaction) {
+                $reactionName = $reaction->reaction->reaction_name;
+                
+                if (!isset($reactionInfo[$reactionName])) {
+                    $reactionInfo[$reactionName] = [
+                        'count' => 0,
+                        'image' => $reaction->reaction->reaction_image,
+                        'name' => $reactionName
+                    ];
+                }
+                $reactionInfo[$reactionName]['count']++;
+                $reaction->reaction_name = $reactionName;
+            }
+            $post->reaction_stats = array_values($reactionInfo);
             
             return $post;
         });
@@ -47,11 +63,9 @@ class PostController extends Controller
 
     public function show(Request $request, $id)
     {
-        // $postsは単一のPostモデルインスタンス
         $post = Post::with(['user:id,name,user_icon', 'postfile', 'post_reactions.reaction'])
             ->findOrFail($id);
     
-        // 単一モデル内のリレーションを直接操作する
         if ($post->postfile) {
             $post->postfile->transform(function ($file) {
                 // ファイルのパスからAPI経由のURLを生成し、フィールドとして追加
@@ -59,13 +73,28 @@ class PostController extends Controller
                 return $file;
             });
         }
+
+        $reactionInfo = [];
+        foreach ($post->post_reactions as $reaction) {
+            $reactionName = $reaction->reaction->reaction_name;
+            
+            if (!isset($reactionInfo[$reactionName])) {
+                $reactionInfo[$reactionName] = [
+                    'count' => 0,
+                    'image' => $reaction->reaction->reaction_image,
+                    'name' => $reactionName
+                ];
+            }
+            $reactionInfo[$reactionName]['count']++;
+            $reaction->reaction_name = $reactionName;
+        }
+        $post->reaction_stats = array_values($reactionInfo);
     
         return response()->json([
             'success' => true,
             'message' => '取得に成功しました',
             'data' => [
-                // 変数名を$postsから$postに変更すると、より意図が明確になります
-                'posts' => $post 
+                'post' => $post 
             ]
         ]);
     }
@@ -121,12 +150,10 @@ class PostController extends Controller
             ], 201);
     
         } catch (Throwable $th) {
-            // 4. エラー発生時のクリーンアップ処理
             if (DB::transactionLevel() > 0) {
-                DB::rollBack(); // DBへの変更をロールバック
+                DB::rollBack();
             }
     
-            // アップロードに成功していたファイルをすべて削除（ゴミファイル対策）
             if (!empty($uploadedPaths)) {
                 Storage::disk('public')->delete($uploadedPaths);
             }
@@ -141,8 +168,6 @@ class PostController extends Controller
 
     public function delete(PostDeleteRequest $request, $id) 
     {   
-
-        // 削除された投稿のIDを事前に保持
         $post = Post::findOrFail($id);
         $deletedPostId = $post->id;
         
@@ -161,7 +186,7 @@ class PostController extends Controller
                 }
                 
                 $post->delete(); 
-            }); // トランザクションが成功すれば commit
+            }); 
             
             return response()->json([
                 'success' => true,


### PR DESCRIPTION
新しくpostsの中にreaction_statsを追加

こんな感じに追加されていると思う
```json
                "reaction_stats": [
                    {
                        "count": 2,
                        "image": "http://127.0.0.1:8777/storage/reactions/face/grinning.svg",
                        "name": "grinning"
                    },
                    {
                        "count": 2,
                        "image": "http://127.0.0.1:8777/storage/reactions/face/blush.svg",
                        "name": "blush"
                    },
                    {
                        "count": 1,
                        "image": "http://127.0.0.1:8777/storage/reactions/face/smiley.svg",
                        "name": "smiley"
                    },
                    {
                        "count": 1,
                        "image": "http://127.0.0.1:8777/storage/reactions/face/laughing.svg",
                        "name": "laughing"
                    }
                ],
```