### PR TITLE
Feature/ryouma/fixed bug

### DIFF
--- a/laravel_app/app/Http/Controllers/Api/AccountController.php
+++ b/laravel_app/app/Http/Controllers/Api/AccountController.php
@@ -293,6 +293,10 @@ class AccountController extends Controller
                 'name' => $user->name,
                 'user_icon' => $user->user_icon,
                 'point' => $user->points->point ?? 0,
+                'priority' => User::where('user_job', 'player')
+                    ->leftJoin('points', 'users.id', '=', 'points.user_id')
+                    ->where('points.point', '>', ($user->points->point ?? 0))
+                    ->count() + 1,
             ];
         });
 


### PR DESCRIPTION
以下のような感じにpriorityの情報が追加され、それは順位の情報となっています。また、同率の場合は
１位、２位、２位、２位、５位みたいな感じになるはずです
```json
                {
                    "id": 4,
                    "name": "junpei the userw",
                    "user_icon": "http://127.0.0.1:8777/assets/images/default_user_icon.svg",
                    "point": 10000,
                    "priority": 2
                },
```