### PR TITLE
fix: DealerCreateSeederの追加、Makefileにコマンドの追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,9 @@ start:
 	@docker compose up -d
 	@docker compose run app bash
 
+storedealer:
+	@docker compose run app php artisan db:seed --class=DealerCreateSeeder
+	@docker compose run app cat storage/app/public/DealerToken.txt
+
+getdealer:
+	@docker compose run app cat storage/app/public/DealerToken.txt

--- a/laravel_app/database/seeders/DealerCreateSeeder.php
+++ b/laravel_app/database/seeders/DealerCreateSeeder.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\User;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
+
+class DealerCreateSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $filepath = storage_path('app/public/DealerToken.txt');
+        $user = User::create([
+            'name' => 'Dealer',
+            'user_path' => '12dea34ler4',
+            'password' => Hash::make('dealer1234'),
+            'user_icon' => 'default_user_icon',
+            'biography' => null,
+            'game_play_flag' => 0,
+            'user_job' => 'dealer',
+        ]);
+
+        $token = $user->createToken('authToken')->plainTextToken;
+        file_put_contents($filepath, $token);
+
+    }
+}


### PR DESCRIPTION
ディーラーのアカウントを作成するSeederを追加

Makefileにコマンドを追加、使い方
`storedealer` -> Dealerアカウントが作成され、Token情報を取得
`getdealer` -> Token情報を取得するだけ