### PR TITLE
壁に貼るQRコードのバックエンド側のシステムとウォレットのデータの取得方法を修正

### DIFF
--- a/laravel_app/app/Http/Controllers/Api/AccountController.php
+++ b/laravel_app/app/Http/Controllers/Api/AccountController.php
@@ -201,52 +201,42 @@ class AccountController extends Controller
             ]
         ]);
     }
-    public function wallet(WalletFillterRequest $request)
-    {
-        $user = $request->user()->load('points');
-        $user = $user->only('id', 'name', 'user_icon');
-        $user['point'] = $request->user()->points->point;
-        if ($request->input('filter') == "all") {
-            $pointlogs = $request->user()->pointlogs()->paginate(10);
-            $pointlogs->transform(function ($pointlog) {
-                $pointlog->type = ($pointlog->type == 'get' || $pointlog->type == 'import') ? 'plus' : 'minus';
-                $pointlog->date = $pointlog->created_at->format('m/d');
-                $pointlog->time = $pointlog->created_at->format('H:i');
-                unset($pointlog->created_at);
-                return $pointlog;
-
-            });
-        } else if ($request->input('filter') == "plus") {
-            $pointlogs = $request->user()->pointlogs()->whereIn('type', ['get', 'import'])->paginate(10);
-            $pointlogs->transform(function ($pointlog) {
-                $pointlog->type = 'plus';
-                $pointlog->date = $pointlog->created_at->format('m/d');
-                $pointlog->time = $pointlog->created_at->format('H:i');
-                unset($pointlog->created_at);
-                return $pointlog;
-            });
-        } else if ($request->input('filter') == "minus") {
-            $pointlogs = $request->user()->pointlogs()->whereIn('type', ['use', 'export'])->paginate(10);
-            $pointlogs->transform(function ($pointlog) {
-                $pointlog->type = 'minus';
-                $pointlog->date = $pointlog->created_at->format('m/d');
-                $pointlog->time = $pointlog->created_at->format('H:i');
-                unset($pointlog->created_at);
-                return $pointlog;
-            });
-        }
-
-
-
-        return response()->json([
-            'success' => true,
-            'message' => '取得に成功しました',
-            'data' => [
-                'user' => $user,
-                'pointlogs' => $pointlogs
-            ]
-        ]);
+public function wallet(WalletFillterRequest $request)
+{
+    $user = $request->user()->load('points');
+    $user = $user->only('id', 'name', 'user_icon');
+    $user['point'] = $request->user()->points->point;
+    
+    $query = $request->user()->pointlogs();
+    
+    // フィルターに応じてクエリを構築
+    if ($request->input('filter') == "plus") {
+        $query->where('point_amount', '>', 0);
+    } else if ($request->input('filter') == "minus") {
+        $query->where('point_amount', '<', 0);
     }
+    
+    $pointlogs = $query->paginate(10);
+    
+    $pointlogs->transform(function ($pointlog) {
+        // ポイントの増減を数値で表現（プラス・マイナスをそのまま使用）
+        $pointlog->point_amount = (int)$pointlog->point_amount;
+        $pointlog->type = $pointlog->point_amount >= 0 ? 'plus' : 'minus';
+        $pointlog->date = $pointlog->created_at->format('m/d');
+        $pointlog->time = $pointlog->created_at->format('H:i');
+        unset($pointlog->created_at);
+        return $pointlog;
+    });
+
+    return response()->json([
+        'success' => true,
+        'message' => '取得に成功しました',
+        'data' => [
+            'user' => $user,
+            'pointlogs' => $pointlogs
+        ]
+    ]);
+}
     public function wallet_update(WalletUpdateRequest $request , $sns_id){
         //設計の改善の必要あり、ブランチを変更して作成します。
         $user = User::where('id', $sns_id)->with('points')->first();

--- a/laravel_app/app/Http/Controllers/Api/PointRecoveryController.php
+++ b/laravel_app/app/Http/Controllers/Api/PointRecoveryController.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Exception;
+use App\Models\PointRecoverySession;
+use App\Http\Requests\UseRecoveryRequest;
+use App\Http\Requests\QrCreateRequest;
+use App\Http\Requests\QrDeleteRequest;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+
+class PointRecoveryController extends Controller
+{
+    
+    public function use_recovery(UseRecoveryRequest $request)
+    {
+        $user = $request->user();
+        $token = $request->input('token');
+        
+        try {
+            $session = PointRecoverySession::where('token', $token)->firstOrFail();
+
+            // トークンが既に使用済みかチェック
+            if ($user->point_recovery_users()->where('point_recovery_session_id', $session->id)->exists()) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'このトークンは既に使用されています',
+                ], 400);
+            }
+
+            DB::beginTransaction();
+            
+            try {
+                // ユーザーのポイントを更新（Pointモデルを経由）
+                $user->points()->increment('point', $session->amount);
+                
+                // ポイントログを作成
+                $user->pointlogs()->create([
+                    'point_amount' => $session->amount,
+                    'service_name' => $session->service_name,
+                    'description' => $session->description,
+                    'type' => $session->type,
+                ]);
+                
+                // 使用済みトークンを記録
+                $user->point_recovery_users()->attach($session->id);
+                
+                DB::commit();
+                
+                // 更新後のポイントを取得
+                $updatedPoint = $user->points()->first()->point;
+                
+                return response()->json([
+                    'success' => true,
+                    'message' => 'ポイント回復に成功しました',
+                    'data' => [
+                        'new_balance' => $updatedPoint
+                    ]
+                ], 200);
+                
+            } catch (\Exception $e) {
+                DB::rollBack();
+                \Log::error('Point recovery transaction error: ' . $e->getMessage());
+                \Log::error($e->getTraceAsString());
+                
+                return response()->json([
+                    'success' => false,
+                    'message' => 'ポイントの更新中にエラーが発生しました',
+                    'error' => config('app.debug') ? $e->getMessage() : null,
+                ], 500);
+            }
+            
+        } catch (\Illuminate\Database\Eloquent\ModelNotFoundException $e) {
+            return response()->json([
+                'success' => false,
+                'message' => '有効なトークンが見つかりません',
+            ], 404);
+        } catch (\Exception $e) {
+            \Log::error('Point recovery error: ' . $e->getMessage());
+            \Log::error($e->getTraceAsString());
+            
+            return response()->json([
+                'success' => false,
+                'message' => '予期せぬエラーが発生しました',
+                'error' => config('app.debug') ? $e->getMessage() : null,
+            ], 500);
+        }
+    }
+    
+    public function index()
+    {
+        $sessions = PointRecoverySession::all();
+        return response()->json([
+            'success' => true,
+            'data' => $sessions,
+        ], 200);
+    }
+    
+    public function create(QrCreateRequest $request)
+    {
+        $validated = $request->validated();
+        $token = bin2hex(string: random_bytes(16));
+        if($validated['expires_at']){
+            $expires_at = now()->addMinutes($validated['expires_at']);
+        }
+        $session = PointRecoverySession::create([
+            'token' => $token,
+            'amount' => $validated['amount'],
+            'service_name' => $validated['service_name'],
+            'description' => $validated['description'],
+            'type' => $validated['type'],
+            'expires_at' => $expires_at ?? null,
+        ]);
+        return response()->json([
+            'success' => true,
+            'message' => 'QRコードの作成に成功しました',
+            'data' => $session,
+        ], 200);
+    }
+    
+    public function delete(QrDeleteRequest $request)
+    {
+        $id = $request->id;
+        $session = PointRecoverySession::findOrFail($id);
+        $session->delete();
+        return response()->json([
+            'success' => true,
+            'message' => 'QRコードの削除に成功しました',
+        ], 200);
+    }
+}

--- a/laravel_app/app/Http/Requests/QrCreateRequest.php
+++ b/laravel_app/app/Http/Requests/QrCreateRequest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Contracts\Validation\Validator;
+
+class QrCreateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return auth()->user()->user_job === 'admin';
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'amount' => 'required|integer',
+            'service_name' => 'required|string',
+            'description' => 'required|string',
+            'type' => 'required|string',
+            'expires_at' => 'nullable|integer',
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'amount.required' => '金額が入力されていません',
+            'amount.string' => '金額は文字列で入力してください',
+            'amount.integer' => '金額は整数で入力してください',
+            'service_name.required' => 'サービス名が入力されていません',
+            'service_name.string' => 'サービス名は文字列で入力してください',
+            'description.required' => '説明が入力されていません',
+            'description.string' => '説明は文字列で入力してください',
+            'type.required' => 'タイプが入力されていません',
+            'type.string' => 'タイプは文字列で入力してください',
+            'expires_at.integer' => '有効期限は整数で入力してください。また、有効期限は今から何分後かを入力してください',
+        ];
+    }   
+
+    public function failedAuthorization()
+    {
+        return response()->json([
+            'success' => false,
+            'message' => '管理者権限がありません',
+        ], 401);
+    }
+    public function failedValidation(Validator $validator)
+    {
+        throw new HttpResponseException(
+            response()->json([
+                'success' => false,
+                'messages' => collect($validator->errors()->messages())
+                    ->flatten()
+                    ->toArray()
+            ], 422)
+        );
+    } 
+}

--- a/laravel_app/app/Http/Requests/QrDeleteRequest.php
+++ b/laravel_app/app/Http/Requests/QrDeleteRequest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Contracts\Validation\Validator;
+
+class QrDeleteRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return auth()->user()->user_job === 'admin';
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'id' => 'required|exists:point_recovery_sessions,id',
+        ];
+    }
+    
+    public function messages(): array
+    {
+        return [
+            'id.required' => 'QRコードIDが入力されていません',
+            'id.exists' => 'QRコードIDが見つかりませんでした',
+        ];
+    }   
+    
+    public function failedAuthorization()
+    {
+        return response()->json([
+            'success' => false,
+            'message' => '管理者権限がありません',
+        ], 401);
+    }
+    public function failedValidation(Validator $validator)
+    {
+        throw new HttpResponseException(
+            response()->json([
+                'success' => false,
+                'messages' => collect($validator->errors()->messages())
+                    ->flatten()
+                    ->toArray()
+            ], 422)
+        );
+    } 
+}

--- a/laravel_app/app/Http/Requests/UseRecoveryRequest.php
+++ b/laravel_app/app/Http/Requests/UseRecoveryRequest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Contracts\Validation\Validator;
+use App\Models\PointRecoverySession;
+
+class UseRecoveryRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return auth()->check();
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'token' => [
+                'required',
+                'string',
+                'exists:point_recovery_sessions,token',
+                function ($attribute, $value, $fail) {
+                    $session = PointRecoverySession::where('token', $value)->first();
+                    
+                    if ($session && $session->expires_at && $session->expires_at->isPast()) {
+                        $fail('このポイント回復トークンは有効期限が切れています');
+                    }
+                },
+            ],
+        ];
+    }
+    public function messages(): array
+    {
+        return [
+            'point_recovery_token.required' => 'ポイント回復トークンが入力されていません',
+            'point_recovery_token.string' => 'ポイント回復トークンは文字列で入力してください',
+            'point_recovery_token.exists' => 'ポイント回復トークンが見つかりませんでした',
+        ];
+    }   
+    public function failedValidation(Validator $validator)
+    {
+        throw new HttpResponseException(
+            response()->json([
+                'success' => false,
+                'messages' => collect($validator->errors()->messages())
+                    ->flatten()
+                    ->toArray()
+            ], 422)
+        );
+    }  
+}

--- a/laravel_app/app/Models/PointRecoverySession.php
+++ b/laravel_app/app/Models/PointRecoverySession.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class PointRecoverySession extends Model
+{
+    //
+    protected $fillable = [
+        'token',
+        'amount',
+        'service_name',
+        'description',
+        'type',
+        'expires_at',
+    ];
+
+    protected $casts = [
+        'expires_at' => 'datetime',  // 日付文字列をCarbonインスタンスに変換
+    ];
+    
+    public function users()
+    {
+        return $this->belongsToMany(User::class, 'point_recovery_users', 'point_recovery_session_id', 'user_id')
+                    ->withTimestamps();
+    }
+}

--- a/laravel_app/app/Models/User.php
+++ b/laravel_app/app/Models/User.php
@@ -73,6 +73,11 @@ class User extends Authenticatable
     {
         return $this->hasMany(Post::class);
     }
+
+    public function point_recovery_users()
+    {
+        return $this->belongsToMany(PointRecoverySession::class, 'point_recovery_users', 'user_id', 'point_recovery_session_id');
+    }
     
     /**
      * ユーザーが作成した投稿へのリアクションを取得

--- a/laravel_app/database/migrations/2025_11_12_100950_create_point_recovery_sessions_table.php
+++ b/laravel_app/database/migrations/2025_11_12_100950_create_point_recovery_sessions_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('point_recovery_sessions', function (Blueprint $table) {
+            $table->id();
+            $table->string('token')->unique();
+            $table->integer('amount');
+            $table->string('service_name');
+            $table->text('description');
+            $table->enum('type', ['get','use','import','export','expire'])->default('get');
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('point_recovery_sessions');
+    }
+};

--- a/laravel_app/database/migrations/2025_11_12_101015_point_recovery_users.php
+++ b/laravel_app/database/migrations/2025_11_12_101015_point_recovery_users.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('point_recovery_users', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained('users')->onDelete('cascade');
+            $table->foreignId('point_recovery_session_id')->constrained('point_recovery_sessions')->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('point_recovery_users');
+    }
+};

--- a/laravel_app/database/seeders/TestDataSeeder.php
+++ b/laravel_app/database/seeders/TestDataSeeder.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\PointLog;
+use App\Models\User;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Carbon;
+
+class TestDataSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $user = User::find(1);
+        
+        if (!$user) {
+            $user = User::create([
+                'id' => 1,
+                'name' => 'テストユーザー',
+                'email' => 'test@example.com',
+                'password' => bcrypt('password'),
+                'user_icon' => 'default_user_icon',
+                'user_job' => 'player'
+            ]);
+
+            $user->points()->create([
+                'point' => 10000,
+            ]);
+        }
+
+        // テストデータの作成
+        $now = now();
+        $pointLogs = [];
+
+        for ($i = 0; $i < 100; $i++) {
+            // ランダムにポイントを生成（-1000 〜 1000の範囲）
+            $pointAmount = rand(-1000, 1000);
+            
+            $pointLogs[] = [
+                'user_id' => 1,
+                'service_name' => 'テストサービス' . ($i % 5 + 1), // 5つのサービス名をローテーション
+                'description' => 'テストデータ ' . ($i + 1),
+                'point_amount' => $pointAmount,
+                'created_at' => $now->copy()->subDays(rand(0, 30))->addHours(rand(0, 23))->addMinutes(rand(0, 59)),
+                'updated_at' => now(),
+            ];
+        }
+
+        // 一括挿入
+        PointLog::insert($pointLogs);
+
+        // ユーザーのポイントを更新
+        $totalPoints = PointLog::where('user_id', 1)->sum('point_amount');
+        $user->points()->update(['point' => 10000 + $totalPoints]);
+    }
+}

--- a/laravel_app/routes/api.php
+++ b/laravel_app/routes/api.php
@@ -8,7 +8,7 @@ use App\Http\Controllers\Api\PostController;
 use App\Http\Controllers\Api\ReactionController;
 use App\Http\Controllers\Api\BoothController;
 use App\Http\Controllers\Api\GameController;
-
+use App\Http\Controllers\Api\PointRecoveryController;
 
 
 Route::prefix('account')->group(function () {
@@ -37,6 +37,10 @@ Route::middleware('auth:sanctum')->group(function () {
         Route::get('/ranking', [AccountController::class,'ranking']);
         Route::get('/profile/{id}', [AccountController::class,'profile']);
     });
+    Route::prefix('point-recovery')->group(function () {
+        Route::patch('/use-recovery', [PointRecoveryController::class,'use_recovery']);
+    });
+
     
     Route::prefix('post')->group(function () {
             Route::get('/focus/{id}', [PostController::class,'show']);
@@ -61,6 +65,14 @@ Route::middleware(['auth:sanctum', 'can:is-dealer'])->group(function () {
         Route::prefix('wallet')->group(function () {
             Route::patch('/update/{sns_id}', [AccountController::class,'wallet_update']);
         });
+    });
+});
+
+Route::middleware(['auth:sanctum', 'can:is-admin'])->group(function () {
+    Route::prefix('point-recovery')->group(function () {
+        Route::post('/create', [PointRecoveryController::class,'create']);
+        Route::get('/get', [PointRecoveryController::class,'index']);
+        Route::delete('/delete', [PointRecoveryController::class,'delete']);
     });
 });
 


### PR DESCRIPTION
壁に貼るQRコードのバックエンド側のシステムとウォレットのデータの取得方法を修正

フロントが使うAPI

メソッド:`PACHI`
ルート:`api/point-recovery/use-recovery`

リクエスト
```json
{
    "token":String
}
```

レスポンス
```
{
    "success": false,
    "message": "このトークンは既に使用されています"
} 
||
{
    "success": true,
    "message": "ポイント回復に成功しました",
    "data": {
        "getPoint": Integer,
        "newMyPoint": Integer
    }
}
```